### PR TITLE
add pip check, use more traditional version selector 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 1ac530645296310c61ccb7e767309c6498fa386ccc41499f5ec1f6b57a4dd1c9
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
 
@@ -25,7 +25,7 @@ requirements:
     - ipywidgets >=7.0.0,<8
     - jupyter-cache >=0.4.1,<0.5
     - jupyter-sphinx ==0.3.1
-    - myst-parser ~=0.13.3
+    - myst-parser >=0.13.3,<0.14.0
     - nbconvert >=5.5,<6
     - nbformat >=5.0,<6
     - python >=3.6
@@ -34,9 +34,13 @@ requirements:
     - sphinx-togglebutton >=0.2.2,<0.3
 
 test:
+  requires:
+    - pip
   imports:
     - myst_nb
     - myst_nb.nb_glue
+  commands:
+    - pip check
 
 about:
   home: https://github.com/executablebooks/MyST-NB


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.


In trying to set up a [development environment](https://github.com/conda-forge/staged-recipes/pull/12516#issuecomment-774761464 for `jupyter-book`), I've run into issues with the dependency that uses the tilde operator. this uses the more explicit `>=x,<x+1` form. 

Also adds pip check, given the number of deps we're dealing with here. 

Since I'm not super in need of this package until `jupyter-book` is available, i haven't added myself as a maintainer, but would be happy to do so at that time!